### PR TITLE
fix compilation warnings : implicit conversion from int to string

### DIFF
--- a/MQLUnitTestSuite.mqh
+++ b/MQLUnitTestSuite.mqh
@@ -40,7 +40,7 @@ private:
    TearDown          m_tearDownFunc_OnNewCandle[];
    int               m_TearDownExecuteOnCandleCount[][2]; // holds canlde count on which to teardown function and execution status
    bool              m_onInitTestsExecuted;
-   
+
    void              DisplayResults();
 public:
    bool              NotEmpty();
@@ -81,7 +81,7 @@ void CUnitTestSuite::DisplayResults()
    int total;
    string summary;
    bool summaryState = true;
-   
+
    for(int i = 0; i < countOfAsserts; i++)  // For all unit tests
      {
       total = asserts.TotalFailedTests();
@@ -140,16 +140,28 @@ void CUnitTestSuite::DisplayResults()
             lastTestName=currentName;
             continue;
          }
-         Print("testSuite.AddUnitTestFunction("+startCount+", "+(asserts.GetCandleCount()-1)+", "+lastTestName+");");
+         PrintFormat("testSuite.AddUnitTestFunction(%i, %i, %s);",
+          startCount,
+          (asserts.GetCandleCount()-1),
+          lastTestName
+         );
          startCount = asserts.GetCandleCount();
          lastTestName=currentName;
       }
-      if (asserts.TotalFailedTests()>0) { 
-         Print("testSuite.AddUnitTestFunction("+asserts.GetCandleCount()+", "+asserts.GetCandleCount()+", "+currentName+"); // Failed");
+      if (asserts.TotalFailedTests()>0) {
+         Print("testSuite.AddUnitTestFunction(%i, %i, %s); // Failed",
+          asserts.GetCandleCount(),
+          asserts.GetCandleCount(),
+          currentName
+         );
          lastFailingCandlecount = asserts.GetCandleCount();
-      } 
+      }
       if (i==(countOfAsserts-1)) {
-        Print("testSuite.AddUnitTestFunction("+startCount+", "+((asserts.GetCandleCount()))+", "+lastTestName+");");
+        Print("testSuite.AddUnitTestFunction(%i, %i, %s);",
+          startCount,
+          asserts.GetCandleCount(),
+          lastTestName
+        );
       }
       asserts = m_unitTestsAssertList.GetNextNode();
      }
@@ -173,20 +185,40 @@ void CUnitTestSuite::DisplayResults()
      {
       currentName = asserts.GetTestName();
       if (asserts.TotalFailedTests()>0) {
-         Print("testSuite.AddUnitTestFunction("+startCount+", "+(asserts.GetCandleCount()-1)+", "+lastTestName+");");
+         PrintFormat("testSuite.AddUnitTestFunction(%i, %i, %s);",
+          startCount,
+          (asserts.GetCandleCount()-1),
+          lastTestName
+         );
          if (asserts.getTradeActionType()==MQLUNIT_TRADEACTION_BUY)
-            Print("testSuite.AddUnitTestFunction("+asserts.GetCandleCount()+", "+asserts.GetCandleCount()+", Test_DoTrading_ShouldPlaceBuyOrder);");
+            PrintFormat("testSuite.AddUnitTestFunction(%i, %i, Test_DoTrading_ShouldPlaceBuyOrder);",
+              asserts.GetCandleCount(),
+              asserts.GetCandleCount()
+            );
          if (asserts.getTradeActionType()==MQLUNIT_TRADEACTION_SELL)
-            Print("testSuite.AddUnitTestFunction("+asserts.GetCandleCount()+", "+asserts.GetCandleCount()+", Test_DoTrading_ShouldPlaceSellOrder);");
+            PrintFormat("testSuite.AddUnitTestFunction(%i, %i, Test_DoTrading_ShouldPlaceSellOrder);",
+              asserts.GetCandleCount(),
+              asserts.GetCandleCount()
+            );
          if (asserts.getTradeActionType()==MQLUNIT_TRADEACTION_CLOSEBUY)
-            Print("testSuite.AddUnitTestFunction("+asserts.GetCandleCount()+", "+asserts.GetCandleCount()+", Test_DoTrading_ShouldCloseBuyOrder);");
+            PrintFormat("testSuite.AddUnitTestFunction(%i, %i, Test_DoTrading_ShouldCloseBuyOrder);",
+              asserts.GetCandleCount(),
+              asserts.GetCandleCount()
+            );
          if (asserts.getTradeActionType()==MQLUNIT_TRADEACTION_CLOSESELL)
-            Print("testSuite.AddUnitTestFunction("+asserts.GetCandleCount()+", "+asserts.GetCandleCount()+", Test_DoTrading_ShouldCloseSellOrder);");
+            PrintFormat("testSuite.AddUnitTestFunction(%i, %i, Test_DoTrading_ShouldCloseSellOrder);",
+              asserts.GetCandleCount(),
+              asserts.GetCandleCount()
+            );
          startCount = asserts.GetCandleCount()+1;
          lastTestName=currentName;
       }
       if (i==(countOfAsserts-1)) {
-        Print("testSuite.AddUnitTestFunction("+startCount+", "+((asserts.GetCandleCount()))+", "+lastTestName+");");
+        PrintFormat("testSuite.AddUnitTestFunction(%i, %i, %s);",
+          startCount,
+          asserts.GetCandleCount(),
+          lastTestName
+        );
       }
       asserts = m_unitTestsAssertList.GetNextNode();
      }
@@ -201,7 +233,7 @@ void CUnitTestSuite::AddUnitTestAsserts(CUnitTestAsserts* ut)
   }
 
 //+------------------------------------------------------------------+
-//| Add a unit test function to the suite, that executes OnInit                          
+//| Add a unit test function to the suite, that executes OnInit
 //+------------------------------------------------------------------+
 void CUnitTestSuite::AddUnitTestFunction(UnitTest testFunc)
   {
@@ -224,7 +256,7 @@ void CUnitTestSuite::AddUnitTestFunction(int onCandleCount, UnitTest testFunc)
   }
 
 //+------------------------------------------------------------------+
-//| Add unit test functions from index a->b to the suite that executes 
+//| Add unit test functions from index a->b to the suite that executes
 //| on open of specific new candle, before the test cases
 //+------------------------------------------------------------------+
 void CUnitTestSuite::AddUnitTestFunction(int onCandleCountA, int onCandleCountB, UnitTest testFunc)
@@ -331,7 +363,7 @@ void CUnitTestSuite::ExecuteOnInitTests(void)
   }
 
 //+------------------------------------------------------------------+
-//| Executes unit tests that are supposed to run on open of a 
+//| Executes unit tests that are supposed to run on open of a
 //| specific candle
 //+------------------------------------------------------------------+
 void CUnitTestSuite::ExecuteNewCandleTests(int currentCandleCount)


### PR DESCRIPTION
Hi

I'm using vscode, then several lines with trailing spaces have been trimmed. 

i'm also using linux, then please double check the end of modified lines. I'm not sure that CRLF will remain on the lines I changed.